### PR TITLE
Merge feature/json-caching into master

### DIFF
--- a/src/Controller/AbstractDataController.php
+++ b/src/Controller/AbstractDataController.php
@@ -159,7 +159,9 @@
 			else if ($data === null)
 				return $this->responder->createNotFoundResponse();
 
-			return $this->responder->createResponse($data);
+			return $this->responder->createResponse($data, null, [
+				'Cache-Control' => 'public, max-age=14400',
+			]);
 		}
 
 		/**


### PR DESCRIPTION
## Changelog
- API endpoints now properly set the `Cache-Control` headers, to allow responses to be cached both by the client and on Cloudflare's network.