### PR TITLE
Merge fix/missing-weapon-defense-boost into release/1.9.1

### DIFF
--- a/src/Game/Attribute.php
+++ b/src/Game/Attribute.php
@@ -3,9 +3,10 @@
 
 	final class Attribute {
 		// -- General Attributes --
+		const DEFENSE = 'defense';
 		const HEALTH = 'health';
-		const STAMINA = 'stamina';
 		const REQUIRED_GENDER = 'requiredGender';
+		const STAMINA = 'stamina';
 
 		/**
 		 * @deprecated Use {@see WeaponSharpness} instead. Will be removed 2018-05-05.
@@ -94,7 +95,6 @@
 		const SPECIAL_AMMO = 'specialAmmo';
 
 		// -- Armor Attributes --
-		const DEFENSE = 'defense';
 		const RES_FIRE = 'resistFire';
 		const RES_WATER = 'resistWater';
 		const RES_THUNDER = 'resistThunder';

--- a/src/Scraping/Scrapers/Helpers/KiranicoWeaponParser/MainWeaponDataParser.php
+++ b/src/Scraping/Scrapers/Helpers/KiranicoWeaponParser/MainWeaponDataParser.php
@@ -12,6 +12,7 @@
 			Interpreter\RarityInterpreter::class,
 			Interpreter\SlotsInterpreter::class,
 			Interpreter\ElementInterpreter::class,
+			Interpreter\DefenseBoostInterpreter::class,
 
 			// -- Melee Only --
 			Interpreter\SharpnessInterpreter::class,

--- a/src/Scraping/Scrapers/Helpers/KiranicoWeaponParser/WeaponDataInterpreters/DefenseBoostInterpreter.php
+++ b/src/Scraping/Scrapers/Helpers/KiranicoWeaponParser/WeaponDataInterpreters/DefenseBoostInterpreter.php
@@ -1,0 +1,26 @@
+<?php
+	namespace App\Scraping\Scrapers\Helpers\KiranicoWeaponParser\WeaponDataInterpreters;
+
+	use App\Game\Attribute;
+	use App\Scraping\Scrapers\Helpers\KiranicoWeaponParser\WeaponData;
+	use App\Scraping\Scrapers\Helpers\KiranicoWeaponParser\WeaponDataInterpreterInterface;
+	use App\Utility\StringUtil;
+	use Symfony\Component\DomCrawler\Crawler;
+
+	class DefenseBoostInterpreter implements WeaponDataInterpreterInterface {
+		/**
+		 * {@inheritdoc}
+		 */
+		public function supports(Crawler $node): bool {
+			return strpos($node->filter('small.text-muted')->text(), 'Defense') !== false;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function parse(Crawler $node, WeaponData $target): void {
+			$value = str_replace('+', '', StringUtil::clean($node->filter('.lead')->text()));
+
+			$target->setAttribute(Attribute::DEFENSE, (int)$value);
+		}
+	}


### PR DESCRIPTION
## Changelog
- Weapons that boost defense (such as ["Barroth Blaster 3"](http://127.0.0.1:8000/weapons/661)) will now provide that value in `attributes.defense`.