### PR TITLE
Merge fix/missing-skillrank-field into master

### DIFF
--- a/src/Controller/SkillsDataController.php
+++ b/src/Controller/SkillsDataController.php
@@ -39,7 +39,7 @@
 						'id' => $rank->getId(),
 						'slug' => $rank->getSlug(),
 						'skill' => $skill->getId(),
-						'skillName' => $skill->getId(),
+						'skillName' => $skill->getName(),
 						'level' => $rank->getLevel(),
 						'description' => $rank->getDescription(),
 						'modifiers' => $rank->getModifiers(),


### PR DESCRIPTION
## Changelog
- Fixed the skill's ID being returned in the `skillName` field for objects in `Skill.ranks`.