### PR TITLE
Merge fix/inconsistent-modifier-data-type into master

### DIFF
--- a/src/Controller/ArmorDataController.php
+++ b/src/Controller/ArmorDataController.php
@@ -78,7 +78,7 @@
 						'slug' => $rank->getSlug(),
 						'level' => $rank->getLevel(),
 						'description' => $rank->getDescription(),
-						'modifiers' => $rank->getModifiers(),
+						'modifiers' => $rank->getModifiers() ?: new \stdClass(),
 						'skill' => $rank->getSkill()->getId(),
 						'skillName' => $rank->getSkill()->getName(),
 					];

--- a/src/Controller/ArmorSetsDataController.php
+++ b/src/Controller/ArmorSetsDataController.php
@@ -205,7 +205,7 @@
 										'slug' => $skillRank->getSlug(),
 										'level' => $skillRank->getLevel(),
 										'description' => $skillRank->getDescription(),
-										'modifiers' => $skillRank->getModifiers(),
+										'modifiers' => $skillRank->getModifiers() ?: new \stdClass(),
 									];
 
 									if ($projection->isAllowed('bonus.ranks.skill.skill'))

--- a/src/Controller/SkillsDataController.php
+++ b/src/Controller/SkillsDataController.php
@@ -50,7 +50,7 @@
 						'skillName' => $rank->getSkill()->getName(),
 						'level' => $rank->getLevel(),
 						'description' => $rank->getDescription(),
-						'modifiers' => $rank->getModifiers(),
+						'modifiers' => $rank->getModifiers() ?: new \stdClass(),
 					];
 				}, $entity->getRanks()->toArray());
 			}


### PR DESCRIPTION
This resolves [MHWDB-Docs#32](https://github.com/LartTyler/MHWDB-Docs/issues/32).

## Changelog
- Fixed a bug wherein a `SkillRank` object with no items in it's `modifiers` field would return an empty array instead of an empty object.