### PR TITLE
Merge feature/jwt-display-name into release/1.15.0

### DIFF
--- a/config/services/security.yaml
+++ b/config/services/security.yaml
@@ -32,4 +32,11 @@ services:
                 event: lexik_jwt_authentication.on_jwt_expired
                 method: onTokenExpired
 
+    App\Security\CustomizePayloadListener:
+        tags:
+            -
+                name: kernel.event_listener
+                event: lexik_jwt_authentication.on_jwt_created
+                method: onJwtCreate
+
     App\Security\DisabledUserChecker: ~

--- a/src/Security/CustomizePayloadListener.php
+++ b/src/Security/CustomizePayloadListener.php
@@ -17,7 +17,9 @@
 				return;
 
 			$payload = $event->getData();
+
 			$payload['displayName'] = $user->getDisplayName();
+			$payload['roles'] = $user->getRoleNames();
 
 			$event->setData($payload);
 		}

--- a/src/Security/CustomizePayloadListener.php
+++ b/src/Security/CustomizePayloadListener.php
@@ -1,0 +1,24 @@
+<?php
+	namespace App\Security;
+
+	use App\Entity\User;
+	use Lexik\Bundle\JWTAuthenticationBundle\Event\JWTCreatedEvent;
+
+	class CustomizePayloadListener {
+		/**
+		 * @param JWTCreatedEvent $event
+		 *
+		 * @return void
+		 */
+		public function onJwtCreate(JWTCreatedEvent $event): void {
+			$user = $event->getUser();
+
+			if (!($user instanceof User))
+				return;
+
+			$payload = $event->getData();
+			$payload['displayName'] = $user->getDisplayName();
+
+			$event->setData($payload);
+		}
+	}


### PR DESCRIPTION
## Changelog
- Added user display names to auth tokens.
- Fixed roles being encoded as empty objects when serialized as part of a JWT payload.