### PR TITLE
Merge fix/missing-length-fields into release/1.15.0

### DIFF
--- a/src/Command/SyncEntityLengthCachesCommand.php
+++ b/src/Command/SyncEntityLengthCachesCommand.php
@@ -11,6 +11,8 @@
 	use App\Entity\CharmRankCraftingInfo;
 	use App\Entity\Decoration;
 	use App\Entity\LengthCachingEntityInterface;
+	use App\Entity\Location;
+	use App\Entity\Monster;
 	use App\Entity\MotionValue;
 	use App\Entity\Skill;
 	use App\Entity\Weapon;
@@ -31,6 +33,8 @@
 			CharmRank::class,
 			CharmRankCraftingInfo::class,
 			Decoration::class,
+			Location::class,
+			Monster::class,
 			MotionValue::class,
 			Skill::class,
 			Weapon::class,

--- a/src/Entity/Location.php
+++ b/src/Entity/Location.php
@@ -17,7 +17,7 @@
 	 *
 	 * @package App\Entity
 	 */
-	class Location implements EntityInterface {
+	class Location implements EntityInterface, LengthCachingEntityInterface {
 		use EntityTrait;
 
 		/**
@@ -45,6 +45,14 @@
 		 * @var Camp[]|Collection|Selectable
 		 */
 		private $camps;
+
+		/**
+		 * @ORM\Column(type="integer", options={"unsigned": true, "default": 0})
+		 *
+		 * @var int
+		 * @internal Used to allow API queries against "camps.length"
+		 */
+		private $campsLength = 0;
 
 		/**
 		 * Location constructor.
@@ -118,5 +126,12 @@
 				return null;
 
 			return $matching->first();
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function syncLengthFields(): void {
+			$this->campsLength = $this->camps->count();
 		}
 	}

--- a/src/Entity/Monster.php
+++ b/src/Entity/Monster.php
@@ -19,7 +19,7 @@
 	 *
 	 * @package App\Entity
 	 */
-	class Monster implements EntityInterface {
+	class Monster implements EntityInterface, LengthCachingEntityInterface {
 		use EntityTrait;
 
 		/**
@@ -107,6 +107,30 @@
 		 * @see Element::DAMAGE
 		 */
 		private $elements = [];
+
+		/**
+		 * @ORM\Column(type="integer", options={"unsigned": true, "default": 0})
+		 *
+		 * @var int
+		 * @internal Used to allow API queries against "ailments.length"
+		 */
+		private $ailmentsLength = 0;
+
+		/**
+		 * @ORM\Column(type="integer", options={"unsigned": true, "default": 0})
+		 *
+		 * @var int
+		 * @internal Used to allow API queries against "locations.length"
+		 */
+		private $locationsLength = 0;
+
+		/**
+		 * @ORM\Column(type="integer", options={"unsigned": true, "default": 0})
+		 *
+		 * @var int
+		 * @internal Used to allow API queries against "elements.length"
+		 */
+		private $elementsLength = 0;
 
 		/**
 		 * Monster constructor.
@@ -242,5 +266,14 @@
 		 */
 		public function getWeaknesses() {
 			return $this->weaknesses;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		public function syncLengthFields(): void {
+			$this->ailmentsLength = $this->ailments->count();
+			$this->locationsLength = $this->locations->count();
+			$this->elementsLength = sizeof($this->elements);
 		}
 	}

--- a/src/Migrations/Version20190416135847.php
+++ b/src/Migrations/Version20190416135847.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types = 1);
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190416135847 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE locations ADD camps_length INT UNSIGNED DEFAULT 0 NOT NULL');
+			$this->addSql('ALTER TABLE monsters ADD ailments_length INT UNSIGNED DEFAULT 0 NOT NULL, ADD locations_length INT UNSIGNED DEFAULT 0 NOT NULL, ADD elements_length INT UNSIGNED DEFAULT 0 NOT NULL');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE locations DROP camps_length');
+			$this->addSql('ALTER TABLE monsters DROP ailments_length, DROP locations_length, DROP elements_length');
+		}
+	}

--- a/src/QueryDocument/ApiQueryManager.php
+++ b/src/QueryDocument/ApiQueryManager.php
@@ -10,6 +10,8 @@
 	use App\Entity\CharmRank;
 	use App\Entity\CharmRankCraftingInfo;
 	use App\Entity\Decoration;
+	use App\Entity\Location;
+	use App\Entity\Monster;
 	use App\Entity\MotionValue;
 	use App\Entity\Skill;
 	use App\Entity\SkillRank;
@@ -25,55 +27,65 @@
 		public function __construct(ObjectManager $objectManager, array $operators = [], $useBuiltin = true) {
 			parent::__construct($objectManager, $operators, $useBuiltin);
 
-			$this->setAllMappedFields([
-				Armor::class => [
-					'skills.length' => 'skillsLength',
-					'slots.length' => 'slotsLength',
-				],
-				ArmorAssets::class => [
-					'imageMale' => 'imageMale.uri',
-					'imageFemale' => 'imageFemale.uri',
-				],
-				ArmorCraftingInfo::class => [
-					'materials.length' => 'materialsLength',
-				],
-				ArmorSet::class => [
-					'pieces.length' => 'piecesLength',
-				],
-				ArmorSetBonus::class => [
-					'ranks.length' => 'ranksLength',
-				],
-				Charm::class => [
-					'ranks.length' => 'ranksLength',
-				],
-				CharmRank::class => [
-					'skills.length' => 'skillsLength',
-				],
-				CharmRankCraftingInfo::class => [
-					'materials.length' => 'materialsLength',
-				],
-				Decoration::class => [
-					'skills.length' => 'skillsLength',
-				],
-				MotionValue::class => [
-					'hits.length' => 'hitsLength',
-				],
-				Skill::class => [
-					'ranks.length' => 'ranksLength',
-				],
-				SkillRank::class => [
-					'skillName' => 'skill.name',
-				],
-				Weapon::class => [
-					'elements.length' => 'elementsLength',
-					'slots.length' => 'slotsLength',
-					'durability.length' => 'durabilityLength',
-				],
-				WeaponCraftingInfo::class => [
-					'branches.length' => 'branchesLength',
-					'craftingMaterials.length' => 'craftingMaterialsLength',
-					'upgradeMaterials.length' => 'upgradeMaterialsLength',
-				],
-			]);
+			$this->setAllMappedFields(
+				[
+					Armor::class => [
+						'skills.length' => 'skillsLength',
+						'slots.length' => 'slotsLength',
+					],
+					ArmorAssets::class => [
+						'imageMale' => 'imageMale.uri',
+						'imageFemale' => 'imageFemale.uri',
+					],
+					ArmorCraftingInfo::class => [
+						'materials.length' => 'materialsLength',
+					],
+					ArmorSet::class => [
+						'pieces.length' => 'piecesLength',
+					],
+					ArmorSetBonus::class => [
+						'ranks.length' => 'ranksLength',
+					],
+					Charm::class => [
+						'ranks.length' => 'ranksLength',
+					],
+					CharmRank::class => [
+						'skills.length' => 'skillsLength',
+					],
+					CharmRankCraftingInfo::class => [
+						'materials.length' => 'materialsLength',
+					],
+					Decoration::class => [
+						'skills.length' => 'skillsLength',
+					],
+					Location::class => [
+						'camps.length' => 'campsLength',
+					],
+					Monster::class => [
+						'ailments.length' => 'ailmentsLength',
+						'locations.length' => 'locationsLength',
+						'elements.length' => 'elementsLength',
+					],
+					MotionValue::class => [
+						'hits.length' => 'hitsLength',
+					],
+					Skill::class => [
+						'ranks.length' => 'ranksLength',
+					],
+					SkillRank::class => [
+						'skillName' => 'skill.name',
+					],
+					Weapon::class => [
+						'elements.length' => 'elementsLength',
+						'slots.length' => 'slotsLength',
+						'durability.length' => 'durabilityLength',
+					],
+					WeaponCraftingInfo::class => [
+						'branches.length' => 'branchesLength',
+						'craftingMaterials.length' => 'craftingMaterialsLength',
+						'upgradeMaterials.length' => 'upgradeMaterialsLength',
+					],
+				]
+			);
 		}
 	}


### PR DESCRIPTION
## Changelog
- Added the following missing length fields: `monster.ailments.length`, `monster.locations.length`, `monster.elements.length`, `location.camps.length`.