### PR TITLE
Merge fix/missing-stun-weakness into release/1.15.0

### DIFF
--- a/src/Entity/WeaponElement.php
+++ b/src/Entity/WeaponElement.php
@@ -27,7 +27,7 @@
 
 		/**
 		 * @Assert\NotBlank()
-		 * @Assert\Choice(callback={"App\Game\Element", "all"})
+		 * @Assert\Choice(callback={"App\Game\Element", "getAllowedWeaponElements"})
 		 *
 		 * @ORM\Column(type="string", length=16)
 		 *

--- a/src/Game/Element.php
+++ b/src/Game/Element.php
@@ -56,6 +56,21 @@
 		}
 
 		/**
+		 * @return array
+		 */
+		public static function getAllowedWeaponElements() {
+			return array_merge(
+				self::DAMAGE,
+				[
+					self::BLAST,
+					self::POISON,
+					self::SLEEP,
+					self::PARALYSIS,
+				]
+			);
+		}
+
+		/**
 		 * @param string $string
 		 *
 		 * @return bool

--- a/src/Game/Element.php
+++ b/src/Game/Element.php
@@ -10,6 +10,7 @@
 		const BLAST = 'blast';
 		const POISON = 'poison';
 		const SLEEP = 'sleep';
+		const STUN = 'stun';
 		const PARALYSIS = 'paralysis';
 
 		const ALL = [
@@ -21,6 +22,7 @@
 			self::BLAST,
 			self::POISON,
 			self::SLEEP,
+			self::STUN,
 			self::PARALYSIS,
 		];
 
@@ -36,6 +38,7 @@
 			self::BLAST,
 			self::POISON,
 			self::SLEEP,
+			self::STUN,
 			self::PARALYSIS,
 		];
 


### PR DESCRIPTION
## Changelog
- Added "stun" as an allowed element (cannot be used as a weapon's damage type).