### PR TITLE
Merge feature/extract-elderseal-from-attributes into release/1.16.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -87,9 +87,10 @@
 			"./bin/console --ansi doctrine:migrations:diff"
 		],
 		"db:migrate": "./bin/console --ansi doctrine:migrations:migrate",
-		"db:reset": [
-			"./db-reset.sh latest",
-			"@db:migrate"
+		"deploy": [
+			"git pull",
+			"composer install",
+			"composer db:migrate"
 		]
 	},
 	"conflict": {

--- a/src/Command/ExtractEldersealAttributeCommand.php
+++ b/src/Command/ExtractEldersealAttributeCommand.php
@@ -6,6 +6,7 @@
 	use Doctrine\ORM\EntityManagerInterface;
 	use Symfony\Component\Console\Command\Command;
 	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Input\InputOption;
 	use Symfony\Component\Console\Output\OutputInterface;
 	use Symfony\Component\Console\Style\SymfonyStyle;
 
@@ -31,8 +32,17 @@
 			$this->entityManager = $entityManager;
 		}
 
+		protected function configure() {
+			$this->addOption(
+				'delete-attribute',
+				null,
+				InputOption::VALUE_NONE,
+				'If set, deletes old elderseal attributes during processing'
+			);
+		}
+
 		/**
-		 * @param InputInterface  $input
+		 * @param InputInterface $input
 		 * @param OutputInterface $output
 		 *
 		 * @return void
@@ -48,7 +58,9 @@
 
 				if ($elderseal = $weapon->getAttribute(Attribute::ELDERSEAL)) {
 					$weapon->setElderseal($elderseal);
-					$weapon->removeAttribute(Attribute::ELDERSEAL);
+
+					if ($input->getOption('delete-attribute'))
+						$weapon->removeAttribute(Attribute::ELDERSEAL);
 				}
 			}
 

--- a/src/Command/ExtractEldersealAttributeCommand.php
+++ b/src/Command/ExtractEldersealAttributeCommand.php
@@ -1,0 +1,60 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use Doctrine\ORM\EntityManagerInterface;
+	use Symfony\Component\Console\Command\Command;
+	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Output\OutputInterface;
+	use Symfony\Component\Console\Style\SymfonyStyle;
+
+	class ExtractEldersealAttributeCommand extends Command {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected static $defaultName = 'app:tools:extract-elderseal-attributes';
+
+		/**
+		 * @var EntityManagerInterface
+		 */
+		protected $entityManager;
+
+		/**
+		 * ExtractEldersealAttributeCommand constructor.
+		 *
+		 * @param EntityManagerInterface $entityManager
+		 */
+		public function __construct(EntityManagerInterface $entityManager) {
+			parent::__construct();
+
+			$this->entityManager = $entityManager;
+		}
+
+		/**
+		 * @param InputInterface  $input
+		 * @param OutputInterface $output
+		 *
+		 * @return void
+		 */
+		protected function execute(InputInterface $input, OutputInterface $output) {
+			$weapons = $this->entityManager->getRepository(Weapon::class)->findAll();
+
+			$io = new SymfonyStyle($input, $output);
+			$io->progressStart(sizeof($weapons));
+
+			foreach ($weapons as $weapon) {
+				$io->progressAdvance();
+
+				if ($elderseal = $weapon->getAttribute(Attribute::ELDERSEAL)) {
+					$weapon->setElderseal($elderseal);
+					$weapon->removeAttribute(Attribute::ELDERSEAL);
+				}
+			}
+
+			$this->entityManager->flush();
+
+			$io->progressFinish();
+			$io->success('Done!');
+		}
+	}

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -6,6 +6,7 @@
 	use App\Entity\WeaponElement;
 	use App\Entity\WeaponSharpness;
 	use App\Entity\WeaponSlot;
+	use App\Game\Attribute;
 	use App\Game\RawDamageMultiplier;
 	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
 	use DaybreakStudios\Utility\EntityTransformers\Exceptions\EntityTransformerException;
@@ -83,8 +84,12 @@
 			if (ObjectUtil::isset($data, 'attributes'))
 				$entity->setAttributes((array)$data->attributes);
 
-			if (ObjectUtil::isset($data, 'elderseal'))
+			if (ObjectUtil::isset($data, 'elderseal')) {
 				$entity->setElderseal($data->elderseal);
+
+				// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+				$entity->setAttribute(Attribute::ELDERSEAL, $data->elderseal);
+			}
 
 			if (ObjectUtil::isset($data, 'slots')) {
 				$entity->getSlots()->clear();

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -83,6 +83,9 @@
 			if (ObjectUtil::isset($data, 'attributes'))
 				$entity->setAttributes((array)$data->attributes);
 
+			if (ObjectUtil::isset($data, 'elderseal'))
+				$entity->setElderseal($data->elderseal);
+
 			if (ObjectUtil::isset($data, 'slots')) {
 				$entity->getSlots()->clear();
 

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -105,6 +105,7 @@
 					'display' => $entity->getAttack()->getDisplay(),
 					'raw' => $entity->getAttack()->getRaw(),
 				],
+				'elderseal' => $entity->getElderseal(),
 				// default to \stdClass to fix an empty array being returned instead of an empty object
 				'attributes' => $entity->getAttributes() ?: new \stdClass(),
 			];

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -1,6 +1,7 @@
 <?php
 	namespace App\Entity;
 
+	use App\Game\Elderseal;
 	use App\Game\WeaponType;
 	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
 	use Doctrine\Common\Collections\ArrayCollection;
@@ -97,6 +98,16 @@
 		 * @var WeaponAttackValues
 		 */
 		private $attack;
+
+		/**
+		 * @Assert\Choice(choices=App\Game\Elderseal::ALL)
+		 *
+		 * @ORM\Column(type="string", length=16, nullable=true)
+		 *
+		 * @var string|null
+		 * @see Elderseal
+		 */
+		private $elderseal = null;
 
 		/**
 		 * @Assert\Valid()
@@ -209,6 +220,24 @@
 		 */
 		public function setRarity(int $rarity): Weapon {
 			$this->rarity = $rarity;
+
+			return $this;
+		}
+
+		/**
+		 * @return string|null
+		 */
+		public function getElderseal(): ?string {
+			return $this->elderseal;
+		}
+
+		/**
+		 * @param string|null $elderseal
+		 *
+		 * @return $this
+		 */
+		public function setElderseal(?string $elderseal) {
+			$this->elderseal = $elderseal;
 
 			return $this;
 		}

--- a/src/Migrations/Version20190712201512.php
+++ b/src/Migrations/Version20190712201512.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190712201512 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons ADD elderseal VARCHAR(16) DEFAULT NULL');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons DROP elderseal');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Moved `Weapon.attributes.elderseal` to `Weapon.elderseal`.

## Deprecations
- On weapons, the `attributes.elderseal` field is now deprecated in favor of the `elderseal` field. It will be removed in v1.17.0.