### PR TITLE
Merge fix/enforce-lowercase-reward-subtype into release/1.16.0

### DIFF
--- a/src/Contrib/Transformers/MonsterTransformer.php
+++ b/src/Contrib/Transformers/MonsterTransformer.php
@@ -172,8 +172,14 @@
 
 						$reward->getConditions()->add($condition);
 
-						if (ObjectUtil::isset($definition, 'subtype'))
-							$condition->setSubtype($definition->subtype);
+						if (ObjectUtil::isset($definition, 'subtype')) {
+							$subtype = $definition->subtype;
+
+							if (is_string($subtype))
+								$subtype = strtolower($subtype);
+
+							$condition->setSubtype($subtype);
+						}
 					}
 				}
 


### PR DESCRIPTION
## Changelog
- Monster reward subtypes are now always lowercase values.