### PR TITLE
Merge feature/extract-bowgun-ammo-attributes into release/1.16.0

### DIFF
--- a/src/Command/ExtractAmmoCapacitiesAttributesCommand.php
+++ b/src/Command/ExtractAmmoCapacitiesAttributesCommand.php
@@ -1,0 +1,83 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Ammo;
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use App\Game\WeaponType;
+	use Doctrine\ORM\EntityManagerInterface;
+	use Symfony\Component\Console\Command\Command;
+	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Input\InputOption;
+	use Symfony\Component\Console\Output\OutputInterface;
+	use Symfony\Component\Console\Style\SymfonyStyle;
+
+	class ExtractAmmoCapacitiesAttributesCommand extends Command {
+		public static $defaultName = 'app:tools:extract-ammo-capacities-attributes';
+
+		/**
+		 * @var EntityManagerInterface
+		 */
+		protected $entityManager;
+
+		/**
+		 * ExtractAmmoCapacitiesAttributesCommand constructor.
+		 *
+		 * @param EntityManagerInterface $entityManager
+		 */
+		public function __construct(EntityManagerInterface $entityManager) {
+			parent::__construct();
+
+			$this->entityManager = $entityManager;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function configure(): void {
+			$this->addOption(
+				'delete-attribute',
+				null,
+				InputOption::VALUE_NONE,
+				'If set, deletes old ammo capacities attributes during processing'
+			);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function execute(InputInterface $input, OutputInterface $output): void {
+			$weapons = $this->entityManager->getRepository(Weapon::class)->findBy(
+				[
+					'type' => [
+						WeaponType::LIGHT_BOWGUN,
+						WeaponType::HEAVY_BOWGUN,
+					],
+				]
+			);
+
+			$io = new SymfonyStyle($input, $output);
+			$io->progressStart(sizeof($weapons));
+
+			foreach ($weapons as $weapon) {
+				$io->progressAdvance();
+
+				if ($capacities = $weapon->getAttribute(Attribute::AMMO_CAPACITIES)) {
+					$weapon->getAmmo()->clear();
+
+					foreach ($capacities as $type => $capacity) {
+						$ammo = new Ammo($weapon, $type);
+						$ammo->setCapacities($capacity);
+
+						if (!$ammo->isEmpty())
+							$weapon->getAmmo()->add($ammo);
+					}
+				}
+			}
+
+			$this->entityManager->flush();
+
+			$io->progressFinish();
+			$io->success('Done!');
+		}
+	}

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -2,6 +2,7 @@
 	namespace App\Controller;
 
 	use App\Contrib\Transformers\WeaponTransformer;
+	use App\Entity\Ammo;
 	use App\Entity\CraftingMaterialCost;
 	use App\Entity\Weapon;
 	use App\Entity\WeaponElement;
@@ -127,6 +128,24 @@
 					},
 					$durability->toArray()
 				);
+			}
+			// endregion
+
+			// region Ammo Capacity Fields
+			if (WeaponType::isBowgun($entity->getType()) && $projection->isAllowed('ammo')) {
+				$normalized = [];
+
+				foreach ($entity->getAmmo() as $ammo) {
+					if ($ammo->isEmpty())
+						continue;
+
+					$normalized[] = [
+						'type' => $ammo->getType(),
+						'capacities' => $ammo->getCapacities(),
+					];
+				}
+
+				$output['ammo'] = $normalized;
 			}
 			// endregion
 

--- a/src/Entity/Ammo.php
+++ b/src/Entity/Ammo.php
@@ -1,0 +1,103 @@
+<?php
+	namespace App\Entity;
+
+	use App\Game\AmmoType;
+	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
+	use Doctrine\ORM\Mapping as ORM;
+	use Symfony\Component\Validator\Constraints as Assert;
+
+	/**
+	 * @ORM\Entity()
+	 * @ORM\Table(
+	 *     name="weapon_ammo",
+	 *     indexes={
+	 *     		@ORM\Index(columns={"type"})
+	 *     }
+	 * )
+	 */
+	class Ammo implements EntityInterface {
+		use EntityTrait;
+
+		/**
+		 * @ORM\ManyToOne(targetEntity="App\Entity\Weapon", inversedBy="ammo")
+		 * @ORM\JoinColumn(nullable=false)
+		 *
+		 * @var Weapon
+		 */
+		protected $weapon;
+
+		/**
+		 * @Assert\NotBlank()
+		 * @Assert\Choice(callback={"App\Game\AmmoType", "all"})
+		 *
+		 * @ORM\Column(type="string", length=32)
+		 *
+		 * @var string
+		 * @see AmmoType
+		 */
+		protected $type;
+
+		/**
+		 * @Assert\All({
+		 * 		@Assert\NotNull(),
+		 * 		@Assert\Type("integer"),
+		 * 		@Assert\Range(min=0, max=99)
+		 * })
+		 *
+		 * @ORM\Column(type="json")
+		 *
+		 * @var int[]
+		 */
+		protected $capacities = [];
+
+		/**
+		 * AbstractAmmoCapacity constructor.
+		 *
+		 * @param Weapon $weapon
+		 * @param string $type
+		 * @see AmmoType
+		 */
+		public function __construct(Weapon $weapon, string $type) {
+			$this->weapon = $weapon;
+			$this->type = $type;
+		}
+
+		/**
+		 * @return Weapon
+		 */
+		public function getWeapon(): Weapon {
+			return $this->weapon;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getType(): string {
+			return $this->type;
+		}
+
+		/**
+		 * @return int[]
+		 */
+		public function getCapacities(): array {
+			return $this->capacities;
+		}
+
+		/**
+		 * @param int[] $capacities
+		 *
+		 * @return $this
+		 */
+		public function setCapacities(array $capacities) {
+			$this->capacities = $capacities;
+
+			return $this;
+		}
+
+		/**
+		 * @return bool
+		 */
+		public function isEmpty(): bool {
+			return sizeof($this->capacities) === 0 || sizeof(array_filter($this->capacities)) === 0;
+		}
+	}

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -100,6 +100,20 @@
 		private $attack;
 
 		/**
+		 * @Assert\Valid()
+		 *
+		 * @ORM\OneToMany(
+		 *     targetEntity="Ammo",
+		 *     mappedBy="weapon",
+		 *     cascade={"all"},
+		 *     orphanRemoval=true
+		 * )
+		 *
+		 * @var Collection|Selectable|Ammo[]
+		 */
+		private $ammo;
+
+		/**
 		 * @Assert\Choice(choices=App\Game\Elderseal::ALL)
 		 *
 		 * @ORM\Column(type="string", length=16, nullable=true)
@@ -112,7 +126,7 @@
 		/**
 		 * @Assert\Valid()
 		 *
-		 * @ORM\OneToOne(targetEntity="App\Entity\Phial", inversedBy="weapon", cascade={"all"})
+		 * @ORM\OneToOne(targetEntity="App\Entity\Phial", inversedBy="weapon", cascade={"all"}, orphanRemoval=true)
 		 * @ORM\JoinColumn()
 		 *
 		 * @var Phial|null
@@ -178,6 +192,7 @@
 			$this->slots = new ArrayCollection();
 			$this->elements = new ArrayCollection();
 			$this->durability = new ArrayCollection();
+			$this->ammo = new ArrayCollection();
 		}
 
 		/**
@@ -368,6 +383,30 @@
 			$this->phial = $phial;
 
 			return $this;
+		}
+
+		/**
+		 * @return Ammo[]|Collection|Selectable
+		 */
+		public function getAmmo() {
+			return $this->ammo;
+		}
+
+		/**
+		 * @param string $type
+		 *
+		 * @return Ammo|null
+		 */
+		public function getAmmoByType(string $type): ?Ammo {
+			$criteria = Criteria::create()
+				->where(Criteria::expr()->eq('type', $type));
+
+			$matched = $this->getAmmo()->matching($criteria);
+
+			if (!$matched->count())
+				return null;
+
+			return $matched->first();
 		}
 
 		/**

--- a/src/Migrations/Version20190815211202.php
+++ b/src/Migrations/Version20190815211202.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types = 1);
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190815211202 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('CREATE TABLE weapon_ammo (id INT UNSIGNED AUTO_INCREMENT NOT NULL, weapon_id INT UNSIGNED NOT NULL, type VARCHAR(32) NOT NULL, capacities LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\', INDEX IDX_579096D595B82273 (weapon_id), INDEX IDX_579096D58CDE5729 (type), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+			$this->addSql('ALTER TABLE weapon_ammo ADD CONSTRAINT FK_579096D595B82273 FOREIGN KEY (weapon_id) REFERENCES weapons (id)');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('DROP TABLE weapon_ammo');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Moved `Weapon.attributes.ammoCapacities` to `Weapon.ammo`.

## Deprecations
- On weapons, the `attributes.ammoCapacities` field is now deprecated in favor of the `ammo` field. It will be removed in v1.17.0.