### PR TITLE
Merge feature/extract-bow-coating-attributes into release/1.16.0

### DIFF
--- a/src/Command/ExtractBowCoatingAttributesCommand.php
+++ b/src/Command/ExtractBowCoatingAttributesCommand.php
@@ -1,0 +1,75 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Phial;
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use App\Game\WeaponType;
+	use Doctrine\ORM\EntityManagerInterface;
+	use Symfony\Component\Console\Command\Command;
+	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Input\InputOption;
+	use Symfony\Component\Console\Output\OutputInterface;
+	use Symfony\Component\Console\Style\SymfonyStyle;
+
+	class ExtractBowCoatingAttributesCommand extends Command {
+		protected static $defaultName = 'app:tools:extract-bow-coating-attributes';
+
+		/**
+		 * @var EntityManagerInterface
+		 */
+		protected $entityManager;
+
+		/**
+		 * ExtractBowCoatingAttributesCommand constructor.
+		 *
+		 * @param EntityManagerInterface $entityManager
+		 */
+		public function __construct(EntityManagerInterface $entityManager) {
+			parent::__construct();
+
+			$this->entityManager = $entityManager;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function configure(): void {
+			$this->addOption(
+				'delete-attribute',
+				null,
+				InputOption::VALUE_NONE,
+				'If set, deletes old bow coating attributes during processing'
+			);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function execute(InputInterface $input, OutputInterface $output): void {
+			$weapons = $this->entityManager->getRepository(Weapon::class)->findBy(
+				[
+					'type' => WeaponType::BOW,
+				]
+			);
+
+			$io = new SymfonyStyle($input, $output);
+			$io->progressStart(sizeof($weapons));
+
+			foreach ($weapons as $weapon) {
+				$io->progressAdvance();
+
+				if ($coatings = $weapon->getAttribute(Attribute::COATINGS)) {
+					$weapon->setCoatings($coatings);
+
+					if ($input->getOption('delete-attribute'))
+						$weapon->removeAttribute(Attribute::COATINGS);
+				}
+			}
+
+			$this->entityManager->flush();
+
+			$io->progressFinish();
+			$io->success('Done!');
+		}
+	}

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -255,6 +255,16 @@
 					$entity->removeAttribute(Attribute::AMMO_CAPACITIES);
 			}
 
+			if (ObjectUtil::isset($data, 'coatings')) {
+				$entity->setCoatings($data->coatings);
+
+				// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+				if ($data->coatings)
+					$entity->setAttribute(Attribute::COATINGS, $data->coatings);
+				else
+					$entity->removeAttribute(Attribute::COATINGS);
+			}
+
 			if (ObjectUtil::isset($data, 'crafting')) {
 				$crafting = $entity->getCrafting();
 				$definition = $data->crafting;

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -149,6 +149,11 @@
 			}
 			// endregion
 
+			// region Bow Coatings
+			if ($entity->getType() === WeaponType::BOW)
+				$output['coatings'] = $entity->getCoatings();
+			// endregion
+
 			// region Phial Fields
 			if (WeaponType::hasPhialType($entity->getType()) && $projection->isAllowed('phial')) {
 				$output['phial'] = [

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -1,6 +1,7 @@
 <?php
 	namespace App\Entity;
 
+	use App\Game\BowCoatingType;
 	use App\Game\Elderseal;
 	use App\Game\WeaponType;
 	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
@@ -132,6 +133,18 @@
 		 * @var Phial|null
 		 */
 		private $phial = null;
+
+		/**
+		 * @Assert\All({
+		 *     @Assert\Choice(callback={"App\Game\BowCoatingType", "all"})
+		 * })
+		 *
+		 * @ORM\Column(type="json")
+		 *
+		 * @var string[]
+		 * @see BowCoatingType
+		 */
+		private $coatings = [];
 
 		/**
 		 * @Assert\Valid()
@@ -407,6 +420,26 @@
 				return null;
 
 			return $matched->first();
+		}
+
+		/**
+		 * @return string[]
+		 * @see BowCoatingType
+		 */
+		public function getCoatings(): array {
+			return $this->coatings;
+		}
+
+		/**
+		 * @param string[] $coatings
+		 *
+		 * @return $this
+		 * @see BowCoatingType
+		 */
+		public function setCoatings(array $coatings) {
+			$this->coatings = $coatings;
+
+			return $this;
 		}
 
 		/**

--- a/src/Migrations/Version20190819180404.php
+++ b/src/Migrations/Version20190819180404.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190819180404 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons ADD coatings LONGTEXT NOT NULL COMMENT \'(DC2Type:json)\'');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons DROP coatings');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Moved `Weapon.attributes.coatings` to `Weapon.coatings`.

## Deprecations
- On weapons, the `attributes.coatings` field is now deprecated in favor of the `coatings` field. It will be removed in v1.17.0.