### PR TITLE
Merge feature/extract-special-ammo-attributes into release/1.6.0

### DIFF
--- a/src/Command/AbstractExtractWeaponAttributeCommand.php
+++ b/src/Command/AbstractExtractWeaponAttributeCommand.php
@@ -1,0 +1,136 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Weapon;
+	use Doctrine\ORM\EntityManagerInterface;
+	use Doctrine\ORM\QueryBuilder;
+	use Symfony\Component\Console\Command\Command;
+	use Symfony\Component\Console\Input\InputInterface;
+	use Symfony\Component\Console\Input\InputOption;
+	use Symfony\Component\Console\Output\OutputInterface;
+	use Symfony\Component\Console\Style\SymfonyStyle;
+	use Symfony\Component\Validator\ConstraintViolationListInterface;
+	use Symfony\Component\Validator\Validator\ValidatorInterface;
+
+	abstract class AbstractExtractWeaponAttributeCommand extends Command {
+		/**
+		 * @var EntityManagerInterface
+		 */
+		protected $entityManager;
+
+		/**
+		 * @var ValidatorInterface
+		 */
+		protected $validator;
+
+		/**
+		 * AbstractExtractWeaponAttributeCommand constructor.
+		 *
+		 * @param EntityManagerInterface $entityManager
+		 * @param ValidatorInterface     $validator
+		 */
+		public function __construct(EntityManagerInterface $entityManager, ValidatorInterface $validator) {
+			parent::__construct();
+
+			$this->entityManager = $entityManager;
+			$this->validator = $validator;
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function configure() {
+			$this
+				->addOption(
+					'delete-attribute',
+					null,
+					InputOption::VALUE_NONE,
+					'If set, the attribute will be deleted during processing'
+				)
+				->addOption(
+					'skip-validation',
+					null,
+					InputOption::VALUE_NONE,
+					'Skip validating entities after attributes are extracted'
+				);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function execute(InputInterface $input, OutputInterface $output) {
+			$qb = $this->entityManager->createQueryBuilder()
+				->from(Weapon::class, 'w')
+				->select('w');
+
+			$this->addQueryBuilderClauses($qb);
+
+			/** @var Weapon[] $weapons */
+			$weapons = $qb->getQuery()->getResult();
+
+			$io = new SymfonyStyle($input, $output);
+			$io->progressStart(sizeof($weapons));
+
+			foreach ($weapons as $weapon) {
+				$io->progressAdvance();
+
+				$this->process($weapon, $input->getOption('delete-attribute'));
+
+				if ($input->getOption('skip-validation'))
+					continue;
+
+				$violations = $this->validate($weapon);
+
+				if ($violations->count() > 0) {
+					$message = sprintf(
+						'Weapon#%d failed validation after update: [%s] %s',
+						$weapon->getId(),
+						$violations->get(0)->getPropertyPath(),
+						$violations->get(0)->getMessage()
+					);
+
+					if ($violations->count() > 1) {
+						$message .= sprintf(
+							' (and %d other%s)',
+							$violations->count() - 1,
+							$violations->count() - 1 !== 1 ? 's' : ''
+						);
+					}
+
+					$io->error($message);
+
+					return;
+				}
+			}
+
+			$this->entityManager->flush();
+
+			$io->progressFinish();
+			$io->success('Done!');
+		}
+
+		/**
+		 * @param QueryBuilder $queryBuilder
+		 *
+		 * @return void
+		 */
+		protected abstract function addQueryBuilderClauses(QueryBuilder $queryBuilder): void;
+
+		/**
+		 * @param Weapon $weapon
+		 *
+		 * @param bool   $deleteAttribute
+		 *
+		 * @return void
+		 */
+		protected abstract function process(Weapon $weapon, bool $deleteAttribute): void;
+
+		/**
+		 * @param Weapon $weapon
+		 *
+		 * @return ConstraintViolationListInterface|null
+		 */
+		protected function validate(Weapon $weapon): ?ConstraintViolationListInterface {
+			return $this->validator->validate($weapon);
+		}
+	}

--- a/src/Command/ExtractSpecialAmmoAttributesCommand.php
+++ b/src/Command/ExtractSpecialAmmoAttributesCommand.php
@@ -1,0 +1,54 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use App\Game\WeaponType;
+	use Doctrine\ORM\QueryBuilder;
+	use Symfony\Component\Validator\ConstraintViolationListInterface;
+
+	class ExtractSpecialAmmoAttributesCommand extends AbstractExtractWeaponAttributeCommand {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected static $defaultName = 'app:tools:extract-special-ammo-attributes';
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function addQueryBuilderClauses(QueryBuilder $queryBuilder): void {
+			$queryBuilder
+				->andWhere('w.type IN (:types)')
+				->setParameter(
+					'types',
+					[
+						WeaponType::LIGHT_BOWGUN,
+						WeaponType::HEAVY_BOWGUN,
+					]
+				);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function process(Weapon $weapon, bool $deleteAttribute): void {
+			$specialAmmo = $weapon->getAttribute(Attribute::SPECIAL_AMMO);
+
+			if (!$specialAmmo)
+				return;
+
+			$weapon->setSpecialAmmo($specialAmmo);
+
+			if ($deleteAttribute)
+				$weapon->removeAttribute(Attribute::SPECIAL_AMMO);
+		}
+
+		/**
+		 * @param Weapon $weapon
+		 *
+		 * @return ConstraintViolationListInterface
+		 */
+		protected function validate(Weapon $weapon): ConstraintViolationListInterface {
+			return $this->validator->validateProperty($weapon, 'specialAmmo');
+		}
+	}

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -93,6 +93,16 @@
 				$entity->setAttribute(Attribute::ELDERSEAL, $data->elderseal);
 			}
 
+			if (ObjectUtil::isset($data, 'specialAmmo')) {
+				$entity->setSpecialAmmo($data->specialAmmo);
+
+				// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+				if ($data->specialAmmo !== null)
+					$entity->setAttribute(Attribute::SPECIAL_AMMO, $data->specialAmmo);
+				else
+					$entity->removeAttribute($data->specialAmmo);
+			}
+
 			if (ObjectUtil::isset($data, 'phial')) {
 				if (!$data->phial) {
 					$entity->setPhial(null);

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -2,7 +2,6 @@
 	namespace App\Controller;
 
 	use App\Contrib\Transformers\WeaponTransformer;
-	use App\Entity\Ammo;
 	use App\Entity\CraftingMaterialCost;
 	use App\Entity\Weapon;
 	use App\Entity\WeaponElement;
@@ -131,25 +130,29 @@
 			}
 			// endregion
 
-			// region Ammo Capacity Fields
-			if (WeaponType::isBowgun($entity->getType()) && $projection->isAllowed('ammo')) {
-				$normalized = [];
+			// region Bowgun Fields
+			if (WeaponType::isBowgun($entity->getType())) {
+				$output['specialAmmo'] = $entity->getSpecialAmmo();
 
-				foreach ($entity->getAmmo() as $ammo) {
-					if ($ammo->isEmpty())
-						continue;
+				if ($projection->isAllowed('ammo')) {
+					$normalized = [];
 
-					$normalized[] = [
-						'type' => $ammo->getType(),
-						'capacities' => $ammo->getCapacities(),
-					];
+					foreach ($entity->getAmmo() as $ammo) {
+						if ($ammo->isEmpty())
+							continue;
+
+						$normalized[] = [
+							'type' => $ammo->getType(),
+							'capacities' => $ammo->getCapacities(),
+						];
+					}
+
+					$output['ammo'] = $normalized;
 				}
-
-				$output['ammo'] = $normalized;
 			}
 			// endregion
 
-			// region Bow Coatings
+			// region Bow Fields
 			if ($entity->getType() === WeaponType::BOW)
 				$output['coatings'] = $entity->getCoatings();
 			// endregion

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -2,6 +2,7 @@
 	namespace App\Entity;
 
 	use App\Game\BowCoatingType;
+	use App\Game\BowgunSpecialAmmo;
 	use App\Game\Elderseal;
 	use App\Game\WeaponType;
 	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
@@ -145,6 +146,16 @@
 		 * @see BowCoatingType
 		 */
 		private $coatings = [];
+
+		/**
+		 * @Assert\Choice(callback={"App\Game\BowgunSpecialAmmo", "all"})
+		 *
+		 * @ORM\Column(type="string", length=32, nullable=true)
+		 *
+		 * @var string|null
+		 * @see BowgunSpecialAmmo
+		 */
+		private $specialAmmo = null;
 
 		/**
 		 * @Assert\Valid()
@@ -454,6 +465,24 @@
 		 */
 		public function setCoatings(array $coatings) {
 			$this->coatings = $coatings;
+
+			return $this;
+		}
+
+		/**
+		 * @return string|null
+		 */
+		public function getSpecialAmmo(): ?string {
+			return $this->specialAmmo;
+		}
+
+		/**
+		 * @param string|null $specialAmmo
+		 *
+		 * @return $this
+		 */
+		public function setSpecialAmmo(?string $specialAmmo) {
+			$this->specialAmmo = $specialAmmo;
 
 			return $this;
 		}

--- a/src/Game/BowgunSpecialAmmo.php
+++ b/src/Game/BowgunSpecialAmmo.php
@@ -6,11 +6,10 @@
 		const WYVERNHEART = 'wyvernheart';
 		const WYVERNSNIPE = 'wyvernsnipe';
 
-		const ALL = [
-			self::WYVERNBLAST,
-			self::WYVERNHEART,
-			self::WYVERNSNIPE,
-		];
+		/**
+		 * @var string[]|null
+		 */
+		private static $types = null;
 
 		/**
 		 * SpecialAmmo constructor.
@@ -24,6 +23,16 @@
 		 * @return bool
 		 */
 		public static function isValid(string $value): bool {
-			return in_array($value, self::ALL);
+			return in_array($value, self::all());
+		}
+
+		/**
+		 * @return string[]
+		 */
+		public static function all() {
+			if (self::$types === null)
+				self::$types = array_values((new \ReflectionClass(self::class))->getConstants());
+
+			return self::$types;
 		}
 	}

--- a/src/Migrations/Version20190913190444.php
+++ b/src/Migrations/Version20190913190444.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190913190444 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons ADD special_ammo VARCHAR(32) DEFAULT NULL');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons DROP special_ammo');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Moved `Weapon.attributes.specialAmmo` to `Weapon.specialAmmo`.

## Deprecations
- On weapons, the `attributes.specialAmmo` field is now deprecated in favor of the `specialAmmo` field. It will be removed in v1.17.0.