### PR TITLE
Merge feature/extract-bowgun-deviation-attributes into release/1.16.0

### DIFF
--- a/src/Command/ExtractDeviationAttributeCommand.php
+++ b/src/Command/ExtractDeviationAttributeCommand.php
@@ -1,0 +1,44 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use App\Game\WeaponType;
+	use Doctrine\ORM\QueryBuilder;
+
+	class ExtractDeviationAttributeCommand extends AbstractExtractWeaponAttributeCommand {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected static $defaultName = 'app:tools:extract-deviation-attributes';
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function addQueryBuilderClauses(QueryBuilder $queryBuilder): void {
+			$queryBuilder
+				->andWhere('w.type IN (:types)')
+				->setParameter(
+					'types',
+					[
+						WeaponType::LIGHT_BOWGUN,
+						WeaponType::HEAVY_BOWGUN,
+					]
+				);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function process(Weapon $weapon, bool $deleteAttribute): void {
+			$deviation = $weapon->getAttribute(Attribute::DEVIATION);
+
+			if (!$deviation)
+				return;
+
+			$weapon->setDeviation($deviation);
+
+			if ($deleteAttribute)
+				$weapon->removeAttribute(Attribute::DEVIATION);
+		}
+	}

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -103,6 +103,15 @@
 					$entity->removeAttribute($data->specialAmmo);
 			}
 
+			if (ObjectUtil::isset($data, 'deviation')) {
+				$entity->setDeviation($data->deviation);
+
+				if ($entity->getDeviation())
+					$entity->setAttribute(Attribute::DEVIATION, $entity->getDeviation());
+				else
+					$entity->removeAttribute(Attribute::DEVIATION);
+			}
+
 			if (ObjectUtil::isset($data, 'phial')) {
 				if (!$data->phial) {
 					$entity->setPhial(null);

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -133,6 +133,7 @@
 			// region Bowgun Fields
 			if (WeaponType::isBowgun($entity->getType())) {
 				$output['specialAmmo'] = $entity->getSpecialAmmo();
+				$output['deviation'] = $entity->getDeviation();
 
 				if ($projection->isAllowed('ammo')) {
 					$normalized = [];

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -2,6 +2,7 @@
 	namespace App\Entity;
 
 	use App\Game\BowCoatingType;
+	use App\Game\BowgunDeviation;
 	use App\Game\BowgunSpecialAmmo;
 	use App\Game\Elderseal;
 	use App\Game\WeaponType;
@@ -156,6 +157,16 @@
 		 * @see BowgunSpecialAmmo
 		 */
 		private $specialAmmo = null;
+
+		/**
+		 * @Assert\Choice(callback={"App\Game\BowgunDeviation", "all"})
+		 *
+		 * @ORM\Column(type="string", length=32, nullable=true)
+		 *
+		 * @var string|null
+		 * @see BowgunDeviation
+		 */
+		private $deviation = null;
 
 		/**
 		 * @Assert\Valid()
@@ -483,6 +494,24 @@
 		 */
 		public function setSpecialAmmo(?string $specialAmmo) {
 			$this->specialAmmo = $specialAmmo;
+
+			return $this;
+		}
+
+		/**
+		 * @return string|null
+		 */
+		public function getDeviation(): ?string {
+			return $this->deviation;
+		}
+
+		/**
+		 * @param string|null $deviation
+		 *
+		 * @return $this
+		 */
+		public function setDeviation(?string $deviation) {
+			$this->deviation = $deviation;
 
 			return $this;
 		}

--- a/src/Game/BowgunDeviation.php
+++ b/src/Game/BowgunDeviation.php
@@ -7,12 +7,10 @@
 		const AVERAGE = 'average';
 		const HIGH = 'high';
 
-		const ALL = [
-			self::NONE,
-			self::LOW,
-			self::AVERAGE,
-			self::HIGH,
-		];
+		/**
+		 * @var string[]|null
+		 */
+		private static $values = null;
 
 		/**
 		 * Deviation constructor.
@@ -21,11 +19,21 @@
 		}
 
 		/**
+		 * @return string[]
+		 */
+		public static function all() {
+			if (self::$values === null)
+				self::$values = array_values((new \ReflectionClass(self::class))->getConstants());
+
+			return self::$values;
+		}
+
+		/**
 		 * @param string $value
 		 *
 		 * @return bool
 		 */
 		public static function isValid(string $value): bool {
-			return in_array($value, self::ALL);
+			return in_array($value, self::all());
 		}
 	}

--- a/src/Migrations/Version20190916180239.php
+++ b/src/Migrations/Version20190916180239.php
@@ -1,0 +1,30 @@
+<?php declare(strict_types = 1);
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190916180239 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons ADD deviation VARCHAR(32) DEFAULT NULL');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE weapons DROP deviation');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Moved `Weapon.attributes.deviation` to `Weapon.deviation`.

## Deprecations
- On weapons, the `attributes.deviation` field is now deprecated in favor of the `deviation` field. It will be removed in v1.17.0.