### PR TITLE
Merge feature/extract-weapon-attributes into release/1.16.0

### DIFF
--- a/src/Command/AbstractExtractWeaponAttributeCommand.php
+++ b/src/Command/AbstractExtractWeaponAttributeCommand.php
@@ -114,7 +114,8 @@
 		 *
 		 * @return void
 		 */
-		protected abstract function addQueryBuilderClauses(QueryBuilder $queryBuilder): void;
+		protected function addQueryBuilderClauses(QueryBuilder $queryBuilder): void {
+		}
 
 		/**
 		 * @param Weapon $weapon

--- a/src/Command/ExtractBoostTypeAttributeCommand.php
+++ b/src/Command/ExtractBoostTypeAttributeCommand.php
@@ -1,0 +1,38 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use App\Game\WeaponType;
+	use Doctrine\ORM\QueryBuilder;
+
+	class ExtractBoostTypeAttributeCommand extends AbstractExtractWeaponAttributeCommand {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected static $defaultName = 'app:tools:extract-boost-type-attributes';
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function addQueryBuilderClauses(QueryBuilder $queryBuilder): void {
+			$queryBuilder
+				->andWhere('w.type = :type')
+				->setParameter('type', WeaponType::INSECT_GLAIVE);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function process(Weapon $weapon, bool $deleteAttribute): void {
+			$boostType = $weapon->getAttribute(Attribute::IG_BOOST_TYPE);
+
+			if (!$boostType)
+				return;
+
+			$weapon->setBoostType($boostType);
+
+			if ($deleteAttribute)
+				$weapon->removeAttribute(Attribute::IG_BOOST_TYPE);
+		}
+	}

--- a/src/Command/ExtractDamageTypeAttributeCommand.php
+++ b/src/Command/ExtractDamageTypeAttributeCommand.php
@@ -1,0 +1,24 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+
+	class ExtractDamageTypeAttributeCommand extends AbstractExtractWeaponAttributeCommand {
+		protected static $defaultName = 'app:tools:extract-damage-type-attributes';
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function process(Weapon $weapon, bool $deleteAttribute): void {
+			$damageType = $weapon->getAttribute(Attribute::DAMAGE_TYPE);
+
+			if (!$damageType)
+				return;
+
+			$weapon->setDamageType($damageType);
+
+			if ($deleteAttribute)
+				$weapon->removeAttribute(Attribute::DAMAGE_TYPE);
+		}
+	}

--- a/src/Command/ExtractShellingTypeAttributeCommand.php
+++ b/src/Command/ExtractShellingTypeAttributeCommand.php
@@ -8,6 +8,8 @@
 	use Doctrine\ORM\QueryBuilder;
 
 	class ExtractShellingTypeAttributeCommand extends AbstractExtractWeaponAttributeCommand {
+		protected static $defaultName = 'app:tools:extract-shelling-type-attributes';
+
 		/**
 		 * {@inheritdoc}
 		 */

--- a/src/Command/ExtractShellingTypeAttributeCommand.php
+++ b/src/Command/ExtractShellingTypeAttributeCommand.php
@@ -6,6 +6,7 @@
 	use App\Game\Attribute;
 	use App\Game\WeaponType;
 	use Doctrine\ORM\QueryBuilder;
+	use Symfony\Component\Validator\ConstraintViolationListInterface;
 
 	class ExtractShellingTypeAttributeCommand extends AbstractExtractWeaponAttributeCommand {
 		protected static $defaultName = 'app:tools:extract-shelling-type-attributes';
@@ -41,5 +42,12 @@
 
 			if ($deleteAttribute)
 				$weapon->removeAttribute(Attribute::GL_SHELLING_TYPE);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function validate(Weapon $weapon): ?ConstraintViolationListInterface {
+			return $this->validator->validateProperty($weapon, 'shelling');
 		}
 	}

--- a/src/Command/ExtractShellingTypeAttributeCommand.php
+++ b/src/Command/ExtractShellingTypeAttributeCommand.php
@@ -1,0 +1,43 @@
+<?php
+	namespace App\Command;
+
+	use App\Entity\Shelling;
+	use App\Entity\Weapon;
+	use App\Game\Attribute;
+	use App\Game\WeaponType;
+	use Doctrine\ORM\QueryBuilder;
+
+	class ExtractShellingTypeAttributeCommand extends AbstractExtractWeaponAttributeCommand {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function addQueryBuilderClauses(QueryBuilder $queryBuilder): void {
+			$queryBuilder
+				->andWhere('w.type = :type')
+				->setParameter('type', WeaponType::GUNLANCE);
+		}
+
+		/**
+		 * {@inheritdoc}
+		 */
+		protected function process(Weapon $weapon, bool $deleteAttribute): void {
+			$shellingType = $weapon->getAttribute(Attribute::GL_SHELLING_TYPE);
+
+			if (!$shellingType)
+				return;
+
+			$parts = explode(' ', $shellingType);
+
+			if (sizeof($parts) !== 2) {
+				throw new \RuntimeException(
+					sprintf('Cannot parse shelling type "%s" (for Weapon#%d)', $shellingType, $weapon->getId())
+				);
+			}
+
+			$shelling = new Shelling($weapon, strtolower($parts[0]), (int)substr($parts[1], 2));
+			$weapon->setShelling($shelling);
+
+			if ($deleteAttribute)
+				$weapon->removeAttribute(Attribute::GL_SHELLING_TYPE);
+		}
+	}

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -3,6 +3,7 @@
 
 	use App\Entity\Ammo;
 	use App\Entity\Phial;
+	use App\Entity\Shelling;
 	use App\Entity\Weapon;
 	use App\Entity\WeaponCraftingInfo;
 	use App\Entity\WeaponElement;
@@ -152,6 +153,43 @@
 
 					// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
 					$entity->setAttribute(Attribute::PHIAL_TYPE, trim($phial->getType() . ' ' . $phial->getDamage()));
+				}
+			}
+
+			if (ObjectUtil::isset($data, 'shelling')) {
+				if (!$data->shelling) {
+					$entity->setShelling(null);
+
+					// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+					$entity->removeAttribute(Attribute::GL_SHELLING_TYPE);
+				} else {
+					$missing = ObjectUtil::getMissingProperties(
+						$data->shelling,
+						[
+							'type',
+							'level',
+						]
+					);
+
+					if ($missing) {
+						throw ValidationException::missingFields(
+							array_map(
+								function(string $item): string {
+									return 'shelling.' . $item;
+								},
+								$missing
+							)
+						);
+					}
+
+					$shelling = new Shelling($entity, $data->shelling->type, $data->shelling->level);
+					$entity->setShelling($shelling);
+
+					// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+					$entity->setAttribute(
+						Attribute::GL_SHELLING_TYPE,
+						sprintf('%s Lv%d', $shelling->getType(), $shelling->getLevel())
+					);
 				}
 			}
 

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -123,6 +123,16 @@
 					$entity->removeAttribute(Attribute::IG_BOOST_TYPE);
 			}
 
+			if (ObjectUtil::isset($data, 'damageType')) {
+				$entity->setDamageType($data->damageType);
+
+				// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+				if ($entity->getDamageType())
+					$entity->setAttribute(Attribute::DAMAGE_TYPE, $entity->getDamageType());
+				else
+					$entity->removeAttribute(Attribute::DAMAGE_TYPE);
+			}
+
 			if (ObjectUtil::isset($data, 'phial')) {
 				if (!$data->phial) {
 					$entity->setPhial(null);

--- a/src/Contrib/Transformers/WeaponTransformer.php
+++ b/src/Contrib/Transformers/WeaponTransformer.php
@@ -106,10 +106,21 @@
 			if (ObjectUtil::isset($data, 'deviation')) {
 				$entity->setDeviation($data->deviation);
 
+				// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
 				if ($entity->getDeviation())
 					$entity->setAttribute(Attribute::DEVIATION, $entity->getDeviation());
 				else
 					$entity->removeAttribute(Attribute::DEVIATION);
+			}
+
+			if (ObjectUtil::isset($data, 'boostType')) {
+				$entity->setBoostType($data->boostType);
+
+				// TODO Preserves BC for 1.15.0, will be removed in 1.17.0
+				if ($entity->getBoostType())
+					$entity->setAttribute(Attribute::IG_BOOST_TYPE, $entity->getBoostType());
+				else
+					$entity->removeAttribute(Attribute::IG_BOOST_TYPE);
 			}
 
 			if (ObjectUtil::isset($data, 'phial')) {

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -111,6 +111,16 @@
 				'damageType' => $entity->getDamageType(),
 			];
 
+			if ($entity->getType() === WeaponType::GUNLANCE && $projection->isAllowed('shelling')) {
+				if ($shelling = $entity->getShelling()) {
+					$output['shelling'] = [
+						'type' => $shelling->getType(),
+						'level' => $shelling->getLevel(),
+					];
+				} else
+					$output['shelling'] = null;
+			}
+
 			// region Durability Fields
 			if (WeaponType::isMelee($entity->getType()) && $projection->isAllowed('durability')) {
 				$durability = $entity->getDurability();

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -158,6 +158,11 @@
 				$output['coatings'] = $entity->getCoatings();
 			// endregion
 
+			// region Insect Glaive Fields
+			if ($entity->getType() === WeaponType::INSECT_GLAIVE)
+				$output['boostType'] = $entity->getBoostType();
+			// endregion
+
 			// region Phial Fields
 			if (WeaponType::hasPhialType($entity->getType()) && $projection->isAllowed('phial')) {
 				$output['phial'] = $entity->getPhial() ? [

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -108,6 +108,7 @@
 				'elderseal' => $entity->getElderseal(),
 				// default to \stdClass to fix an empty array being returned instead of an empty object
 				'attributes' => $entity->getAttributes() ?: new \stdClass(),
+				'damageType' => $entity->getDamageType(),
 			];
 
 			// region Durability Fields

--- a/src/Entity/Shelling.php
+++ b/src/Entity/Shelling.php
@@ -1,0 +1,100 @@
+<?php
+	namespace App\Entity;
+
+	use App\Game\ShellingType;
+	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
+	use Doctrine\ORM\Mapping as ORM;
+	use Symfony\Component\Validator\Constraints as Assert;
+
+	/**
+	 * @ORM\Entity(readOnly=true)
+	 * @ORM\Table(name="weapon_shelling")
+	 */
+	class Shelling implements EntityInterface {
+		use EntityTrait;
+
+		/**
+		 * @ORM\OneToOne(targetEntity="App\Entity\Weapon", inversedBy="shelling")
+		 * @ORM\JoinColumn(nullable=false)
+		 *
+		 * @var Weapon
+		 */
+		private $weapon;
+
+		/**
+		 * @Assert\NotNull()
+		 * @Assert\Choice(callback={"App\Game\ShellingType", "all"})
+		 *
+		 * @ORM\Column(type="string", length=16)
+		 *
+		 * @var string
+		 * @see ShellingType
+		 */
+		private $type;
+
+		/**
+		 * @Assert\NotNull()
+		 * @Assert\Range(min=1)
+		 *
+		 * @ORM\Column(type="smallint", options={"unsigned": true})
+		 *
+		 * @var int
+		 */
+		private $level;
+
+		/**
+		 * Shelling constructor.
+		 *
+		 * @param Weapon $weapon
+		 * @param string $type
+		 * @param int    $level
+		 */
+		public function __construct(Weapon $weapon, string $type, int $level) {
+			$this->weapon = $weapon;
+			$this->type = $type;
+			$this->level = $level;
+		}
+
+		/**
+		 * @return Weapon
+		 */
+		public function getWeapon(): Weapon {
+			return $this->weapon;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getType(): string {
+			return $this->type;
+		}
+
+		/**
+		 * @param string $type
+		 *
+		 * @return $this
+		 */
+		public function setType(string $type) {
+			$this->type = $type;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getLevel(): int {
+			return $this->level;
+		}
+
+		/**
+		 * @param int $level
+		 *
+		 * @return $this
+		 */
+		public function setLevel(int $level) {
+			$this->level = $level;
+
+			return $this;
+		}
+	}

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -4,6 +4,7 @@
 	use App\Game\BowCoatingType;
 	use App\Game\BowgunDeviation;
 	use App\Game\BowgunSpecialAmmo;
+	use App\Game\DamageType;
 	use App\Game\Elderseal;
 	use App\Game\InsectGlaiveBoostType;
 	use App\Game\WeaponType;
@@ -178,6 +179,17 @@
 		 * @see InsectGlaiveBoostType
 		 */
 		private $boostType = null;
+
+		/**
+		 * @Assert\NotNull()
+		 * @Assert\Choice(callback={"App\Game\DamageType", "all"})
+		 *
+		 * @ORM\Column(type="string", length=32, nullable=true)
+		 *
+		 * @var string|null
+		 * @see DamageType
+		 */
+		private $damageType = null;
 
 		/**
 		 * @Assert\Valid()
@@ -541,6 +553,24 @@
 		 */
 		public function setBoostType(?string $boostType) {
 			$this->boostType = $boostType;
+
+			return $this;
+		}
+
+		/**
+		 * @return string|null
+		 */
+		public function getDamageType(): ?string {
+			return $this->damageType;
+		}
+
+		/**
+		 * @param string|null $damageType
+		 *
+		 * @return $this
+		 */
+		public function setDamageType(?string $damageType) {
+			$this->damageType = $damageType;
 
 			return $this;
 		}

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -5,6 +5,7 @@
 	use App\Game\BowgunDeviation;
 	use App\Game\BowgunSpecialAmmo;
 	use App\Game\Elderseal;
+	use App\Game\InsectGlaiveBoostType;
 	use App\Game\WeaponType;
 	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
 	use Doctrine\Common\Collections\ArrayCollection;
@@ -167,6 +168,16 @@
 		 * @see BowgunDeviation
 		 */
 		private $deviation = null;
+
+		/**
+		 * @Assert\Choice(callback={"All\Game\InsectGlaiveBoostType", "all"})
+		 *
+		 * @ORM\Column(type="string", length=32, nullable=true)
+		 *
+		 * @var string|null
+		 * @see InsectGlaiveBoostType
+		 */
+		private $boostType = null;
 
 		/**
 		 * @Assert\Valid()
@@ -512,6 +523,24 @@
 		 */
 		public function setDeviation(?string $deviation) {
 			$this->deviation = $deviation;
+
+			return $this;
+		}
+
+		/**
+		 * @return string|null
+		 */
+		public function getBoostType(): ?string {
+			return $this->boostType;
+		}
+
+		/**
+		 * @param string|null $boostType
+		 *
+		 * @return $this
+		 */
+		public function setBoostType(?string $boostType) {
+			$this->boostType = $boostType;
 
 			return $this;
 		}

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -171,7 +171,7 @@
 		private $deviation = null;
 
 		/**
-		 * @Assert\Choice(callback={"All\Game\InsectGlaiveBoostType", "all"})
+		 * @Assert\Choice(callback={"App\Game\InsectGlaiveBoostType", "all"})
 		 *
 		 * @ORM\Column(type="string", length=32, nullable=true)
 		 *

--- a/src/Entity/Weapon.php
+++ b/src/Entity/Weapon.php
@@ -194,6 +194,15 @@
 		/**
 		 * @Assert\Valid()
 		 *
+		 * @ORM\OneToOne(targetEntity="App\Entity\Shelling", mappedBy="weapon", orphanRemoval=true, cascade={"all"})
+		 *
+		 * @var Shelling|null
+		 */
+		private $shelling = null;
+
+		/**
+		 * @Assert\Valid()
+		 *
 		 * @ORM\OneToOne(targetEntity="App\Entity\WeaponCraftingInfo", orphanRemoval=true, cascade={"all"})
 		 *
 		 * @var WeaponCraftingInfo|null
@@ -571,6 +580,24 @@
 		 */
 		public function setDamageType(?string $damageType) {
 			$this->damageType = $damageType;
+
+			return $this;
+		}
+
+		/**
+		 * @return Shelling|null
+		 */
+		public function getShelling(): ?Shelling {
+			return $this->shelling;
+		}
+
+		/**
+		 * @param Shelling|null $shelling
+		 *
+		 * @return $this
+		 */
+		public function setShelling(?Shelling $shelling) {
+			$this->shelling = $shelling;
 
 			return $this;
 		}

--- a/src/Game/ShellingType.php
+++ b/src/Game/ShellingType.php
@@ -1,0 +1,29 @@
+<?php
+	namespace App\Game;
+
+	final class ShellingType {
+		public const NORMAL = 'normal';
+		public const LONG = 'long';
+		public const WIDE = 'wide';
+
+		/**
+		 * @var string[]|null
+		 */
+		private static $values = null;
+
+		/**
+		 * ShellingType constructor.
+		 */
+		private function __construct() {
+		}
+
+		/**
+		 * @return string[]
+		 */
+		public static function all() {
+			if (self::$values === null)
+				self::$values = array_values((new \ReflectionClass(self::class))->getConstants());
+
+			return self::$values;
+		}
+	}

--- a/src/Migrations/Version20190916211506.php
+++ b/src/Migrations/Version20190916211506.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20190916211506 extends AbstractMigration {
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('CREATE TABLE weapon_shelling (id INT UNSIGNED AUTO_INCREMENT NOT NULL, weapon_id INT UNSIGNED NOT NULL, type VARCHAR(16) NOT NULL, level SMALLINT UNSIGNED NOT NULL, UNIQUE INDEX UNIQ_9415F73295B82273 (weapon_id), PRIMARY KEY(id)) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci ENGINE = InnoDB');
+			$this->addSql('ALTER TABLE weapon_shelling ADD CONSTRAINT FK_9415F73295B82273 FOREIGN KEY (weapon_id) REFERENCES weapons (id)');
+			$this->addSql('ALTER TABLE weapons ADD boost_type VARCHAR(32) DEFAULT NULL, ADD damage_type VARCHAR(32) DEFAULT NULL');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('DROP TABLE weapon_shelling');
+			$this->addSql('ALTER TABLE weapons DROP boost_type, DROP damage_type');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Moved `Weapon.attributes.boostType` to `Weapon.boostType` (insect glaive only).
- Moved `Weapon.attributes.damageType` to `Weapon.damageType`.
- Moved `Weapon.attributes.shellingType` to `Weapon.shelling` (gunlance only).

## Deprecations
- On weapons, `attributes.boostType` is now deprecated in favor of the `boostType` field. It will be removed in v1.17.0.
- On weapons, `attributes.damageType` is now deprecated in favor of the `damageType` field. It will be removed in v1.17.0.
- On weapons, `attributes.shellingType` is now deprecated in favor of the `shelling` field. It will be removed in v1.17.0.