### PR TITLE
Merge fix/max-decoration-rank into master

### DIFF
--- a/src/Entity/Decoration.php
+++ b/src/Entity/Decoration.php
@@ -31,7 +31,7 @@
 
 		/**
 		 * @Assert\NotBlank()
-		 * @Assert\Range(min=1, max=3)
+		 * @Assert\Range(min=1, max=4)
 		 *
 		 * @ORM\Column(type="smallint", options={"unsigned": true})
 		 *


### PR DESCRIPTION
## Changelog
- Updated decoration validation to allow a rank of up to 4, to allow for new Iceborne decorations (fixes LartTyler/MHWDB-Contrib#39).