### PR TITLE
Merge fix/index-docs-redirect into release/1.17.1

### DIFF
--- a/config/routes.yaml
+++ b/config/routes.yaml
@@ -6,7 +6,7 @@ app._annotations:
 
 index:
     path: /
-    controller: 'FrameworkBundle:Redirect:urlRedirect'
+    controller: Symfony\Bundle\FrameworkBundle\Controller\RedirectController
     defaults:
         path: 'https://docs.mhw-db.com/'
 


### PR DESCRIPTION
## Changelog
- Fixed a bug wherein requests to `https://mhw-db.com` were not being redirected to the documentation site.