### PR TITLE
Merge fix/empty-object-serialization into release/1.17.1

### DIFF
--- a/config/services/responder.yaml
+++ b/config/services/responder.yaml
@@ -9,9 +9,14 @@ services:
         arguments:
             -
                 - '@serializer.normalizer.datetime'
-                - '@serializer.normalizer.object'
+                - '@App\Serializer\CustomObjectNormalizer'
             -
                 - '@serializer.encoder.json'
+
+    App\Serializer\CustomObjectNormalizer:
+        bind:
+            $defaultContext:
+                preserve_empty_objects: true
 
     DaybreakStudios\RestApiCommon\Responder:
         bind:

--- a/src/Serializer/CustomObjectNormalizer.php
+++ b/src/Serializer/CustomObjectNormalizer.php
@@ -1,0 +1,17 @@
+<?php
+	namespace App\Serializer;
+
+	use Symfony\Component\Serializer\Normalizer\ObjectNormalizer;
+
+	class CustomObjectNormalizer extends ObjectNormalizer {
+		/**
+		 * {@inheritdoc}
+		 */
+		public function normalize($object, string $format = null, array $context = []) {
+			$context[ObjectNormalizer::PRESERVE_EMPTY_OBJECTS] =
+				$context[ObjectNormalizer::PRESERVE_EMPTY_OBJECTS] ??
+				$this->defaultContext[ObjectNormalizer::PRESERVE_EMPTY_OBJECTS];
+
+			return parent::normalize($object, $format, $context);
+		}
+	}


### PR DESCRIPTION
## Changelog
- Fixed a bug wherein attributes objects (such as `Weapon.attributes` or `SkillRank.modifiers`) would be serialized to an empty array if they contained no keys.