### PR TITLE
Merge fix/uninitialized-charm-rank-strings into master

### DIFF
--- a/src/Entity/CharmRank.php
+++ b/src/Entity/CharmRank.php
@@ -88,6 +88,7 @@
 			$this->charm = $charm;
 			$this->level = $level;
 			$this->skills = new ArrayCollection();
+			$this->strings = new ArrayCollection();
 		}
 
 		/**


### PR DESCRIPTION
## Changelog
- Fixed a bug wherein saving newly added `CharmRank` objects would return a 500 error (fixes LartTyler/MHWDB-Contrib#49).