### PR TITLE
Merge feature/split-item-value into release/1.19.0

### DIFF
--- a/src/Contrib/Transformers/ItemTransformer.php
+++ b/src/Contrib/Transformers/ItemTransformer.php
@@ -53,8 +53,16 @@
 			if (ObjectUtil::isset($data, 'rarity'))
 				$entity->setRarity($data->rarity);
 
-			if (ObjectUtil::isset($data, 'value'))
-				$entity->setValue($data->value);
+			if (ObjectUtil::isset($data, 'buyPrice'))
+				$entity->setBuyPrice($data->buyPrice);
+
+			if (ObjectUtil::isset($data, 'sellPrice')) {
+				$entity->setSellPrice($data->sellPrice);
+
+				// Preserves BC with 1.18
+				// TODO Remove in 1.20.0
+				$entity->setValue($data->sellPrice);
+			}
 
 			if (ObjectUtil::isset($data, 'carryLimit'))
 				$entity->setCarryLimit($data->carryLimit);

--- a/src/Controller/AilmentController.php
+++ b/src/Controller/AilmentController.php
@@ -124,6 +124,8 @@
 								'rarity' => $item->getRarity(),
 								'value' => $item->getValue(),
 								'carryLimit' => $item->getCarryLimit(),
+								'buyPrice' => $item->getBuyPrice(),
+								'sellPrice' => $item->getSellPrice(),
 							];
 
 							if (

--- a/src/Controller/ArmorController.php
+++ b/src/Controller/ArmorController.php
@@ -258,6 +258,8 @@
 										'rarity' => $item->getRarity(),
 										'carryLimit' => $item->getCarryLimit(),
 										'value' => $item->getValue(),
+										'buyPrice' => $item->getBuyPrice(),
+										'sellPrice' => $item->getSellPrice(),
 									];
 
 									if (

--- a/src/Controller/ArmorSetsController.php
+++ b/src/Controller/ArmorSetsController.php
@@ -250,6 +250,8 @@
 													'rarity' => $item->getRarity(),
 													'carryLimit' => $item->getCarryLimit(),
 													'value' => $item->getValue(),
+													'buyPrice' => $item->getBuyPrice(),
+													'sellPrice' => $item->getSellPrice(),
 												];
 
 												if (

--- a/src/Controller/CharmsController.php
+++ b/src/Controller/CharmsController.php
@@ -185,6 +185,8 @@
 													'rarity' => $item->getRarity(),
 													'carryLimit' => $item->getCarryLimit(),
 													'value' => $item->getValue(),
+													'buyPrice' => $item->getBuyPrice(),
+													'sellPrice' => $item->getSellPrice(),
 												];
 
 												if (

--- a/src/Controller/ItemsController.php
+++ b/src/Controller/ItemsController.php
@@ -96,6 +96,8 @@
 				'rarity' => $entity->getRarity(),
 				'carryLimit' => $entity->getCarryLimit(),
 				'value' => $entity->getValue(),
+				'buyPrice' => $entity->getBuyPrice(),
+				'sellPrice' => $entity->getSellPrice(),
 			];
 
 			if ($projection->isAllowed('name') || $projection->isAllowed('description')) {

--- a/src/Controller/MonsterController.php
+++ b/src/Controller/MonsterController.php
@@ -153,6 +153,7 @@
 											'rarity' => $item->getRarity(),
 											'value' => $item->getValue(),
 											'carryLimit' => $item->getCarryLimit(),
+											'sellPrice' => $item->getSellPrice(),
 										];
 
 										if (
@@ -214,6 +215,8 @@
 											'rarity' => $item->getRarity(),
 											'value' => $item->getValue(),
 											'carryLimit' => $item->getCarryLimit(),
+											'buyPrice' => $item->getBuyPrice(),
+											'sellPrice' => $item->getSellPrice(),
 										];
 
 										if (
@@ -314,6 +317,8 @@
 								'rarity' => $item->getRarity(),
 								'carryLimit' => $item->getCarryLimit(),
 								'value' => $item->getValue(),
+								'buyPrice' => $item->getBuyPrice(),
+								'sellPrice' => $item->getSellPrice(),
 							];
 
 							if (

--- a/src/Controller/MonsterRewardsController.php
+++ b/src/Controller/MonsterRewardsController.php
@@ -94,6 +94,8 @@
 					'rarity' => $item->getRarity(),
 					'carryLimit' => $item->getCarryLimit(),
 					'value' => $item->getValue(),
+					'buyPrice' => $item->getBuyPrice(),
+					'sellPrice' => $item->getSellPrice(),
 				];
 
 				if ($projection->isAllowed('item.name') || $projection->isAllowed('item.description')) {

--- a/src/Controller/WeaponsController.php
+++ b/src/Controller/WeaponsController.php
@@ -244,6 +244,8 @@
 										'rarity' => $item->getRarity(),
 										'carryLimit' => $item->getCarryLimit(),
 										'value' => $item->getValue(),
+										'buyPrice' => $item->getBuyPrice(),
+										'sellPrice' => $item->getSellPrice(),
 									];
 
 									if (

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -64,7 +64,7 @@
 		/**
 		 * @Assert\Range(min="0")
 		 *
-		 * @ORM\Column(type="int", options={"unsigned": true})
+		 * @ORM\Column(type="integer", options={"unsigned": true})
 		 *
 		 * @var int
 		 */
@@ -73,7 +73,7 @@
 		/**
 		 * @Assert\Range(min="0")
 		 *
-		 * @ORM\Column(type="int", options={"unsigned": true})
+		 * @ORM\Column(type="integer", options={"unsigned": true})
 		 *
 		 * @var int
 		 */

--- a/src/Entity/Item.php
+++ b/src/Entity/Item.php
@@ -50,6 +50,7 @@
 		 * @ORM\Column(type="integer", options={"unsigned": true}, name="_value")
 		 *
 		 * @var int
+		 * @deprecated Will be removed in 1.20.0
 		 */
 		private $value = 0;
 
@@ -59,6 +60,24 @@
 		 * @var int
 		 */
 		private $carryLimit = 0;
+
+		/**
+		 * @Assert\Range(min="0")
+		 *
+		 * @ORM\Column(type="int", options={"unsigned": true})
+		 *
+		 * @var int
+		 */
+		private $buyPrice = 0;
+
+		/**
+		 * @Assert\Range(min="0")
+		 *
+		 * @ORM\Column(type="int", options={"unsigned": true})
+		 *
+		 * @var int
+		 */
+		private $sellPrice = 0;
 
 		/**
 		 * Item constructor.
@@ -91,6 +110,7 @@
 
 		/**
 		 * @return int
+		 * @deprecated Will be removed in 1.20.0
 		 */
 		public function getValue(): int {
 			return $this->value;
@@ -100,6 +120,7 @@
 		 * @param int $value
 		 *
 		 * @return $this
+		 * @deprecated Will be removed in 1.20.0
 		 */
 		public function setValue(int $value) {
 			$this->value = $value;
@@ -121,6 +142,42 @@
 		 */
 		public function setCarryLimit(int $carryLimit) {
 			$this->carryLimit = $carryLimit;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getBuyPrice(): int {
+			return $this->buyPrice;
+		}
+
+		/**
+		 * @param int $buyPrice
+		 *
+		 * @return $this
+		 */
+		public function setBuyPrice(int $buyPrice) {
+			$this->buyPrice = $buyPrice;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getSellPrice(): int {
+			return $this->sellPrice;
+		}
+
+		/**
+		 * @param int $sellPrice
+		 *
+		 * @return $this
+		 */
+		public function setSellPrice(int $sellPrice) {
+			$this->sellPrice = $sellPrice;
 
 			return $this;
 		}

--- a/src/Migrations/Version20200211231809.php
+++ b/src/Migrations/Version20200211231809.php
@@ -1,0 +1,37 @@
+<?php
+	declare(strict_types=1);
+
+	namespace DoctrineMigrations;
+
+	use Doctrine\DBAL\Schema\Schema;
+	use Doctrine\Migrations\AbstractMigration;
+
+	/**
+	 * Auto-generated Migration: Please modify to your needs!
+	 */
+	final class Version20200211231809 extends AbstractMigration {
+		public function getDescription(): string {
+			return '';
+		}
+
+		public function up(Schema $schema): void {
+			// this up() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE items ADD buy_price INT UNSIGNED NOT NULL, ADD sell_price INT UNSIGNED NOT NULL');
+			$this->addSql('UPDATE items SET sell_price = _value');
+		}
+
+		public function down(Schema $schema): void {
+			// this down() migration is auto-generated, please modify it to your needs
+			$this->abortIf(
+				$this->connection->getDatabasePlatform()->getName() !== 'mysql',
+				'Migration can only be executed safely on \'mysql\'.'
+			);
+
+			$this->addSql('ALTER TABLE items DROP buy_price, DROP sell_price');
+		}
+	}


### PR DESCRIPTION
## Changelog
- Added `buyPrice` and `sellPrice` to items.

## Deprecations
- On items, `value` is now deprecated in favor of the new `buyPrice` and `sellPrice` fields, and will be removed in v1.20.0.