### PR TITLE
Merge feature/quests into release/1.19.0

### DIFF
--- a/src/Entity/Armor.php
+++ b/src/Entity/Armor.php
@@ -42,7 +42,7 @@
 
 		/**
 		 * @Assert\NotBlank()
-		 * @Assert\Choice(callback={"App\Game\Rank", "all"})
+		 * @Assert\Choice(callback={"App\Game\Rank", "values"})
 		 *
 		 * @ORM\Column(type="string", length=16)
 		 *

--- a/src/Entity/ArmorSet.php
+++ b/src/Entity/ArmorSet.php
@@ -23,7 +23,7 @@
 		use EntityTrait;
 
 		/**
-		 * @Assert\Choice(callback={"App\Game\Rank", "all"})
+		 * @Assert\Choice(callback={"App\Game\Rank", "values"})
 		 *
 		 * @ORM\Column(type="string", length=16)
 		 *

--- a/src/Entity/Quest.php
+++ b/src/Entity/Quest.php
@@ -1,0 +1,270 @@
+<?php
+	namespace App\Entity;
+
+	use App\Entity\Strings\QuestStrings;
+	use App\Game\Quest\Objective;
+	use App\Game\Quest\QuestType;
+	use App\Game\Rank;
+	use App\Localization\TranslatableEntityInterface;
+	use DaybreakStudios\Utility\DoctrineEntities\EntityInterface;
+	use Doctrine\Common\Collections\ArrayCollection;
+	use Doctrine\Common\Collections\Collection;
+	use Doctrine\Common\Collections\Selectable;
+	use Doctrine\ORM\Mapping as ORM;
+	use Symfony\Component\Validator\Constraints as Assert;
+
+	/**
+	 * @ORM\Entity()
+	 * @ORM\Table(name="quests")
+	 * @ORM\InheritanceType("SINGLE_TABLE")
+	 * @ORM\DiscriminatorColumn(name="objective", type="string", length=18)
+	 * @ORM\DiscriminatorMap(
+	 *     "capture" = "App\Entity\Quests\CaptureQuest",
+	 *     "gather" = "App\Entity\Quests\GatherQuest",
+	 *     "hunt" = "App\Entity\Quests\HuntQuest",
+	 *     "slay" = "App\Entity\Quests\SlayQuest"
+	 * )
+	 */
+	abstract class Quest implements EntityInterface, TranslatableEntityInterface {
+		use EntityTrait;
+
+		/**
+		 * @Assert\NotBlank()
+		 * @Assert\Choice(callback={"App\Game\Quest\Objective", "values"})
+		 *
+		 * @var string
+		 * @see Objective
+		 */
+		protected $objective = null;
+
+		/**
+		 * @ORM\ManyToOne(targetEntity="App\Entity\Location")
+		 * @ORM\JoinColumn(nullable=false)
+		 *
+		 * @var Location
+		 */
+		protected $location;
+
+		/**
+		 * @Assert\NotBlank()
+		 * @Assert\Choice(callback={"App\Game\Quest\QuestType", "values"})
+		 *
+		 * @var string
+		 * @see QuestType
+		 */
+		protected $type;
+
+		/**
+		 * @Assert\NotBlank()
+		 * @Assert\Choice(callback={"App\Game\Rank", "values"})
+		 *
+		 * @ORM\Column(type="string", length=6)
+		 *
+		 * @var string
+		 * @see Rank
+		 */
+		protected $rank;
+
+		/**
+		 * @Assert\Range(min="1")
+		 *
+		 * @ORM\Column(type="smallint", options={"unsigned": true})
+		 *
+		 * @var int
+		 */
+		protected $stars;
+
+		/**
+		 * @ORM\OneToMany(
+		 *     targetEntity="App\Entity\Strings\QuestStrings",
+		 *     mappedBy="quest",
+		 *     orphanRemoval=true,
+		 *     cascade={"all"},
+		 *     fetch="EAGER"
+		 * )
+		 *
+		 * @var Collection|Selectable|QuestStrings[]
+		 */
+		protected $strings;
+
+		/**
+		 * @Assert\Range(min="1")
+		 *
+		 * @ORM\Column(type="smallint", options={"unsigned": true})
+		 *
+		 * @var int
+		 */
+		protected $timeLimit = 3000;
+
+		/**
+		 * @Assert\Range(min="1")
+		 *
+		 * @ORM\Column(type="smallint", options={"unsigned": true})
+		 *
+		 * @var int
+		 */
+		protected $maxHunters = 4;
+
+		/**
+		 * Quest constructor.
+		 *
+		 * @param Location $location
+		 * @param string   $type
+		 * @param string   $rank
+		 * @param int      $stars
+		 */
+		protected function __construct(Location $location, string $type, string $rank, int $stars) {
+			assert($this->objective !== null);
+
+			$this->location = $location;
+			$this->type = $type;
+			$this->rank = $rank;
+			$this->stars = $stars;
+
+			$this->strings = new ArrayCollection();
+		}
+
+		/**
+		 * @return Location
+		 */
+		public function getLocation(): Location {
+			return $this->location;
+		}
+
+		/**
+		 * @param Location $location
+		 *
+		 * @return $this
+		 */
+		public function setLocation(Location $location) {
+			$this->location = $location;
+
+			return $this;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getObjective(): string {
+			return $this->objective;
+		}
+
+		/**
+		 * @param string $objective
+		 *
+		 * @return $this
+		 */
+		public function setObjective(string $objective) {
+			$this->objective = $objective;
+
+			return $this;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getType(): string {
+			return $this->type;
+		}
+
+		/**
+		 * @param string $type
+		 *
+		 * @return $this
+		 */
+		public function setType(string $type) {
+			$this->type = $type;
+
+			return $this;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getRank(): string {
+			return $this->rank;
+		}
+
+		/**
+		 * @param string $rank
+		 *
+		 * @return $this
+		 */
+		public function setRank(string $rank) {
+			$this->rank = $rank;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getStars(): int {
+			return $this->stars;
+		}
+
+		/**
+		 * @param int $stars
+		 *
+		 * @return $this
+		 */
+		public function setStars(int $stars) {
+			$this->stars = $stars;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getTimeLimit(): int {
+			return $this->timeLimit;
+		}
+
+		/**
+		 * @param int $timeLimit
+		 *
+		 * @return $this
+		 */
+		public function setTimeLimit(int $timeLimit) {
+			$this->timeLimit = $timeLimit;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getMaxHunters(): int {
+			return $this->maxHunters;
+		}
+
+		/**
+		 * @param int $maxHunters
+		 *
+		 * @return $this
+		 */
+		public function setMaxHunters(int $maxHunters) {
+			$this->maxHunters = $maxHunters;
+
+			return $this;
+		}
+
+		/**
+		 * @return Collection|Selectable|QuestStrings[]
+		 */
+		public function getStrings(): Collection {
+			return $this->strings;
+		}
+
+		/**
+		 * @param string $language
+		 *
+		 * @return QuestStrings
+		 */
+		public function addStrings(string $language): EntityInterface {
+			$this->getStrings()->add($strings = new QuestStrings($this, $language));
+
+			return $strings;
+		}
+	}

--- a/src/Entity/Quests/AbstractMonsterTargetQuest.php
+++ b/src/Entity/Quests/AbstractMonsterTargetQuest.php
@@ -1,0 +1,39 @@
+<?php
+	namespace App\Entity\Quests;
+
+	use App\Entity\Monster;
+	use App\Entity\Quest;
+	use Doctrine\Common\Collections\ArrayCollection;
+	use Doctrine\Common\Collections\Collection;
+	use Doctrine\Common\Collections\Selectable;
+	use Doctrine\ORM\Mapping as ORM;
+
+	abstract class AbstractMonsterTargetQuest extends Quest {
+		/**
+		 * @ORM\ManyToMany(targetEntity="App\Entity\Monster")
+		 * @ORM\JoinTable(name="quests_monster_targets")
+		 *
+		 * @var Collection|Selectable|Monster[]
+		 */
+		protected $monsters;
+
+		/**
+		 * AbstractMonsterTargetQuest constructor.
+		 *
+		 * @param string $type
+		 * @param string $rank
+		 * @param int    $stars
+		 */
+		public function __construct(string $type, string $rank, int $stars) {
+			parent::__construct($type, $rank, $stars);
+
+			$this->monsters = new ArrayCollection();
+		}
+
+		/**
+		 * @return Monster[]|Collection|Selectable
+		 */
+		public function getMonsters(): Collection {
+			return $this->monsters;
+		}
+	}

--- a/src/Entity/Quests/CaptureQuest.php
+++ b/src/Entity/Quests/CaptureQuest.php
@@ -1,0 +1,15 @@
+<?php
+	namespace App\Entity\Quests;
+
+	use App\Game\Quest\Objective;
+	use Doctrine\ORM\Mapping as ORM;
+
+	/**
+	 * @ORM\Entity()
+	 */
+	class CaptureQuest extends AbstractMonsterTargetQuest {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected $objective = Objective::CAPTURE;
+	}

--- a/src/Entity/Quests/GatherQuest.php
+++ b/src/Entity/Quests/GatherQuest.php
@@ -1,0 +1,79 @@
+<?php
+	namespace App\Entity\Quests;
+
+	use App\Entity\Item;
+	use App\Entity\Quest;
+	use App\Game\Quest\Objective;
+	use Doctrine\ORM\Mapping as ORM;
+
+	/**
+	 * @ORM\Entity()
+	 */
+	class GatherQuest extends Quest {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected $objective = Objective::GATHER;
+
+		/**
+		 * @var Item
+		 */
+		private $item;
+
+		/**
+		 * @var int
+		 */
+		private $amount;
+
+		/**
+		 * GatherQuest constructor.
+		 *
+		 * @param Item   $item
+		 * @param int    $amount
+		 * @param string $type
+		 * @param string $rank
+		 * @param int    $stars
+		 */
+		public function __construct(Item $item, int $amount, string $type, string $rank, int $stars) {
+			parent::__construct($type, $rank, $stars);
+
+			$this->item = $item;
+			$this->amount = $amount;
+		}
+
+		/**
+		 * @return Item
+		 */
+		public function getItem(): Item {
+			return $this->item;
+		}
+
+		/**
+		 * @param Item $item
+		 *
+		 * @return $this
+		 */
+		public function setItem(Item $item) {
+			$this->item = $item;
+
+			return $this;
+		}
+
+		/**
+		 * @return int
+		 */
+		public function getAmount(): int {
+			return $this->amount;
+		}
+
+		/**
+		 * @param int $amount
+		 *
+		 * @return $this
+		 */
+		public function setAmount(int $amount) {
+			$this->amount = $amount;
+
+			return $this;
+		}
+	}

--- a/src/Entity/Quests/HuntQuest.php
+++ b/src/Entity/Quests/HuntQuest.php
@@ -1,0 +1,15 @@
+<?php
+	namespace App\Entity\Quests;
+
+	use App\Game\Quest\Objective;
+	use Doctrine\ORM\Mapping as ORM;
+
+	/**
+	 * @ORM\Entity()
+	 */
+	class HuntQuest extends AbstractMonsterTargetQuest {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected $objective = Objective::HUNT;
+	}

--- a/src/Entity/Quests/SlayQuest.php
+++ b/src/Entity/Quests/SlayQuest.php
@@ -1,0 +1,15 @@
+<?php
+	namespace App\Entity\Quests;
+
+	use App\Game\Quest\Objective;
+	use Doctrine\ORM\Mapping as ORM;
+
+	/**
+	 * @ORM\Entity()
+	 */
+	class SlayQuest extends AbstractMonsterTargetQuest {
+		/**
+		 * {@inheritdoc}
+		 */
+		protected $objective = Objective::SLAY;
+	}

--- a/src/Entity/RewardCondition.php
+++ b/src/Entity/RewardCondition.php
@@ -29,7 +29,7 @@
 
 		/**
 		 * @Assert\NotBlank()
-		 * @Assert\Choice(callback={"App\Game\Rank", "all"})
+		 * @Assert\Choice(callback={"App\Game\Rank", "values"})
 		 *
 		 * @ORM\Column(type="string", length=16)
 		 *

--- a/src/Entity/Strings/QuestStrings.php
+++ b/src/Entity/Strings/QuestStrings.php
@@ -1,0 +1,90 @@
+<?php
+	namespace App\Entity\Strings;
+
+	use App\Entity\Quest;
+	use App\Localization\StringsEntityInterface;
+	use App\Localization\StringsEntityTrait;
+	use Doctrine\ORM\Mapping as ORM;
+	use Symfony\Component\Validator\Constraints as Assert;
+
+	/**
+	 * @ORM\Entity()
+	 * @ORM\Table(name="quest_strings")
+	 */
+	class QuestStrings implements StringsEntityInterface {
+		use StringsEntityTrait;
+
+		/**
+		 * @ORM\ManyToOne(targetEntity="App\Entity\Quest", inversedBy="strings")
+		 * @ORM\JoinColumn(nullable=false)
+		 *
+		 * @var Quest
+		 */
+		private $quest;
+
+		/**
+		 * @Assert\NotBlank()
+		 * @Assert\Length(max="128")
+		 *
+		 * @ORM\Column(type="string", length=128, unique=true)
+		 *
+		 * @var string
+		 */
+		private $name = null;
+
+		/**
+		 * @Assert\NotBlank()
+		 *
+		 * @ORM\Column(type="text")
+		 *
+		 * @var string
+		 */
+		private $description = null;
+
+		/**
+		 * QuestStrings constructor.
+		 *
+		 * @param Quest  $quest
+		 * @param string $language
+		 */
+		public function __construct(Quest $quest, string $language) {
+			$this->quest = $quest;
+			$this->language = $language;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getName(): string {
+			return $this->name;
+		}
+
+		/**
+		 * @param string $name
+		 *
+		 * @return $this
+		 */
+		public function setName(string $name) {
+			$this->name = $name;
+
+			return $this;
+		}
+
+		/**
+		 * @return string
+		 */
+		public function getDescription(): string {
+			return $this->description;
+		}
+
+		/**
+		 * @param string $description
+		 *
+		 * @return $this
+		 */
+		public function setDescription(string $description) {
+			$this->description = $description;
+
+			return $this;
+		}
+	}

--- a/src/Game/Quest/Objective.php
+++ b/src/Game/Quest/Objective.php
@@ -1,0 +1,13 @@
+<?php
+	namespace App\Game\Quest;
+
+	use DaybreakStudios\RestApiCommon\Utility\ConstantsClassTrait;
+
+	final class Objective {
+		use ConstantsClassTrait;
+
+		public const HUNT = 'hunt';
+		public const SLAY = 'slay';
+		public const CAPTURE = 'capture';
+		public const GATHER = 'gather';
+	}

--- a/src/Game/Quest/QuestType.php
+++ b/src/Game/Quest/QuestType.php
@@ -1,0 +1,18 @@
+<?php
+	namespace App\Game\Quest;
+
+	use DaybreakStudios\RestApiCommon\Utility\ConstantsClassTrait;
+
+	/**
+	 * Longest value: SPECIAL_ASSIGNMENT = 18
+	 */
+	final class QuestType {
+		use ConstantsClassTrait;
+
+		public const ARENA = 'arena';
+		public const ASSIGNMENT = 'assignment';
+		public const CHALLENGE = 'challenge';
+		public const EVENT = 'event';
+		public const OPTIONAL = 'optional';
+		public const SPECIAL_ASSIGNMENT = 'special assignment';
+	}

--- a/src/Game/Rank.php
+++ b/src/Game/Rank.php
@@ -1,29 +1,15 @@
 <?php
 	namespace App\Game;
 
+	use DaybreakStudios\RestApiCommon\Utility\ConstantsClassTrait;
+
+	/**
+	 * Longest value: MASTER = 6
+	 */
 	final class Rank {
+		use ConstantsClassTrait;
+
 		const LOW = 'low';
 		const HIGH = 'high';
 		const MASTER = 'master';
-
-		/**
-		 * @var string[]|null
-		 */
-		private static $ranks = null;
-
-		/**
-		 * ArmorRank constructor.
-		 */
-		private function __construct() {
-		}
-
-		/**
-		 * @return array
-		 */
-		public static function all(): array {
-			if (self::$ranks === null)
-				self::$ranks = array_values((new \ReflectionClass(self::class))->getConstants());
-
-			return self::$ranks;
-		}
 	}


### PR DESCRIPTION
## Changelog
- Coming soon.

## Deprecations
- On Events, quest-related fields (such as `name`, `description`, `location`, etc.) are deprecated in favor of the fields on the new `quest` object. These fields will be removed in 1.20.0.