### PR TITLE
Merge fix/empty-modifiers-on-armor into master

### DIFF
--- a/src/Controller/ArmorSetBonusController.php
+++ b/src/Controller/ArmorSetBonusController.php
@@ -122,7 +122,7 @@
 							$output['skill'] = [
 								'id' => $skill->getId(),
 								'level' => $skill->getLevel(),
-								'modifiers' => $skill->getModifiers(),
+								'modifiers' => $skill->getModifiers() ?: new \stdClass(),
 							];
 
 							if ($projection->isAllowed('ranks.skill.description')) {

--- a/src/Controller/ArmorSetsController.php
+++ b/src/Controller/ArmorSetsController.php
@@ -170,7 +170,7 @@
 									$output = [
 										'id' => $rank->getId(),
 										'level' => $rank->getLevel(),
-										'modifiers' => $rank->getModifiers(),
+										'modifiers' => $rank->getModifiers() ?: new \stdClass(),
 										'skill' => $rank->getSkill()->getId(),
 									];
 


### PR DESCRIPTION
## Changelog
- Fixed a bug wherein skills with empty modifier lists were being normalized to empty arrays instead of objects (reported via Discord).